### PR TITLE
updated broken link for author in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ If you have found a bug or if you have a feature request, please report them at 
 
 ## Author
 
-[Auth0](auth0.com)
+[Auth0](https://auth0.com)
 
 ## License
 


### PR DESCRIPTION
The link the the author "Auth0" was broken due to not having https:// at the beginning.